### PR TITLE
⚒  optimize error handling for empty url param

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -295,6 +295,27 @@ describe('hapi-rest-proxy', () => {
               expect(console.log).toHaveBeenCalledWith(`${template.render(new Date())} | GET | 500 | https://www.i-want-to-test.com/api`)
             })
         })
+
+        test('returns statusCode 400 if the url param is empty', () => {
+          setup()
+
+          return server.route.mock.calls[0][0].handler(
+            {
+              method: 'get',
+              query: { url: '' },
+              payload: undefined
+            },
+            (result) => {
+              expect(result).toBe(400)
+            }
+          )
+            .then(() => {
+              expect(true).toBeFalsy()
+            })
+            .catch(() => {
+              expect(console.log).toHaveBeenCalledWith(`${template.render(new Date())} | GET | 400 | undefined`)
+            })
+        })
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -53,6 +53,11 @@ server.route({
       return reply.file(path.join(__dirname, 'static', 'index.html'))
     }
 
+    if (!request.query.url) {
+      log(method, 400, undefined)
+      return reply(Boom.badRequest('missing param url'))
+    }
+
     const uri = getUrlFromQuery(request.query)
 
     try {
@@ -76,7 +81,7 @@ server.route({
       } else {
         log(method, 500, uri)
 
-        reply(Boom.badImplementation)
+        reply(Boom.badImplementation())
       }
     }
   }


### PR DESCRIPTION
fixes #8 